### PR TITLE
Add support for RFC-2348 (blksize option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ It aims to be easy to use / read.
 
 - [1350 - The TFTP Protocol (Revision 2)](https://www.rfc-editor.org/rfc/rfc1350)
 - [2347 - TFTP Option Extension](https://www.rfc-editor.org/rfc/inline-errata/rfc2347.html)
+- [2348 - TFTP Blocksize Option](https://www.rfc-editor.org/rfc/rfc2348.html)


### PR DESCRIPTION
Adds support for the `blksize` extension as is required by the raspberry pi. Dependent on merging rfc-2347 ( #1 ) and does not update the server code yet.