### PR TITLE
add support for RFC-2349 (Timeout interval and Transfer Size options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ It aims to be easy to use / read.
 
 ### RFCs
 
-- [1350 - The TFTP Protocol (Revision 2)](https://www.rfc-editor.org/rfc/rfc1350)
-- [2347 - TFTP Option Extension](https://www.rfc-editor.org/rfc/inline-errata/rfc2347.html)
-- [2348 - TFTP Blocksize Option](https://www.rfc-editor.org/rfc/rfc2348.html)
+✅ [1350 - The TFTP Protocol (Revision 2)](https://www.rfc-editor.org/rfc/inline-errata/rfc1350.html)
+
+✅ [2347 - TFTP Option Extension](https://www.rfc-editor.org/rfc/inline-errata/rfc2347.html)
+
+✅ [2348 - TFTP Blocksize Option](https://www.rfc-editor.org/rfc/rfc2348.html)
+
+⚠️ [2349 - TFTP Timeout Interval and Transfer Size Options](https://www.rfc-editor.org/rfc/rfc2349.html)
+
+❌ [2090 - TFTP Multicast Option](https://www.rfc-editor.org/rfc/rfc2090.html)


### PR DESCRIPTION
Adds support for `tsize` and `timeout` options in the packet parser. There's no support in the server code yet, needs a clean-up pass.