### PR TITLE
include tsize and timeout when serializing an optionack packet, allow option acks with timeouts to be created

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let transfer = server.create_transfer_to(
                     client_addr,
                     file,
-                    OptionAck::new(block_size, file_size),
+                    OptionAck::new(block_size, file_size, None),
                 )?;
                 //spawn this transfer onto a thread, so that multiple transfers can be handled at once.
                 std::thread::spawn(move || {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -541,18 +541,25 @@ impl<'a> Error<'a> {
     }
 }
 
-impl<'a> OptionAck<'a> {
-    /// Creates an Option Ack packet, optionally including a blocksize as defined in [RFC-2348](https://datatracker.ietf.org/doc/html/rfc2348) or transfer size as defined in [RFC-2349](https://www.rfc-editor.org/rfc/rfc2349.html).
-    pub fn new(blocksize: Option<u16>, transfer_size: Option<u64>) -> Self {
+impl OptionAck<'static> {
+    /// Creates an Option Ack packet, optionally including a blocksize as defined in [RFC-2348](https://datatracker.ietf.org/doc/html/rfc2348), transfer size([RFC-2349](https://www.rfc-editor.org/rfc/rfc2349.html)), or timeout ([RFC-2349](https://www.rfc-editor.org/rfc/rfc2349.html)).
+    pub fn new(
+        blocksize: Option<u16>,
+        transfer_size: Option<u64>,
+        timeout_seconds: Option<NonZeroU8>,
+    ) -> Self {
         //can't _construct_ an option ack with unknown fields because the server wouldn't know how to handle them.
         // we don't support timeouts in the server either, so we don't construct those either.
         Self {
             blocksize,
             transfer_size,
-            timeout_seconds: None,
+            timeout_seconds,
             unknown_options: &[],
         }
     }
+}
+
+impl<'a> OptionAck<'a> {
     fn from_bytes_skip_opcode_check(data: &'a [u8]) -> TftpResult<Self> {
         let mut data = &data[2..];
         let mut blocksize = None;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -607,6 +607,12 @@ impl<'a> OptionAck<'a> {
         if let Some(blocksize) = self.blocksize {
             let _ = write!(write_target, "blksize\0{blocksize}\0");
         }
+        if let Some(tsize) = self.transfer_size {
+            let _ = write!(write_target, "tsize\0{tsize}\0");
+        }
+        if let Some(timeout) = self.timeout_seconds {
+            let _ = write!(write_target, "timeout\0{timeout}\0");
+        }
         if write_target.overflowed() {
             Err(TftpError::BufferTooSmall)
         } else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -58,6 +58,12 @@ impl Server {
         source: R,
         options: OptionAck<'static>,
     ) -> IoResult<Transfer<R>> {
+        if options.timeout_seconds.is_some() {
+            return Err(IoError::new(
+                std::io::ErrorKind::Other,
+                "Server does not support setting a time-out",
+            ));
+        }
         Transfer::new(source, self.sock.sock.local_addr()?.ip(), target, options)
     }
 


### PR DESCRIPTION
the tsize and timeout options weren't actually being serialized when sending an optionack. 